### PR TITLE
Rewrite config file and commandline options

### DIFF
--- a/config.example
+++ b/config.example
@@ -1,4 +1,0 @@
-search=
-subreddit=
-user=
-password=

--- a/scrapify.cfg
+++ b/scrapify.cfg
@@ -1,0 +1,8 @@
+# Example config file
+[scrapify-me]
+search = brocaps
+subreddit = /r/mechmarket
+user = your_username_here
+password = your_password_here
+client-id = reddit_client_id
+client-secret = reddit_client_secret


### PR DESCRIPTION
We needed a way to set default options via configuration file, but override those options on the command line, only if they were set on the command line. 

[ConfigArgParse](https://github.com/bw2/ConfigArgParse) allows us to do exactly that.

I also renamed the config file, ordered imports alphabetically and did some general cleanup around string formatting.